### PR TITLE
Fix travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ gemfile:
   - gemfiles/Gemfile.edge
 matrix:
   exclude:
-    - 1.8.7
-      gemfiles/Gemfile.edge
-    - rbx-18mode
-      gemfiles/Gemfile.edge
-    - jruby-18mode
-      gemfiles/Gemfile.edge
+    - rvm: 1.8.7
+      gemfile: gemfiles/Gemfile.edge
+    - rvm: rbx-18mode
+      gemfile: gemfiles/Gemfile.edge
+    - rvm: jruby-18mode
+      gemfile: gemfiles/Gemfile.edge

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,15 @@ rvm:
   - jruby-19mode
   - ruby-head
 gemfile:
-  - gemfiles/Gemfile.2.3.x
-  - gemfiles/Gemfile.3.0.x
-  - gemfiles/Gemfile.3.1.x
-  - gemfiles/Gemfile.edge
+  - Gemfile.2.3.x
+  - Gemfile.3.0.x
+  - Gemfile.3.1.x
+  - Gemfile.edge
 matrix:
   exclude:
     - rvm: 1.8.7
-      gemfile: gemfiles/Gemfile.edge
+      gemfile: Gemfile.edge
     - rvm: rbx-18mode
-      gemfile: gemfiles/Gemfile.edge
+      gemfile: Gemfile.edge
     - rvm: jruby-18mode
-      gemfile: gemfiles/Gemfile.edge
+      gemfile: Gemfile.edge


### PR DESCRIPTION
So, it's `.travis.yml` of course, sorry about that, i had a bunch of things running in parallel.

Also, it needs to point to your actual gemfiles which are located in the repo root dir in your case.

This now expands the matrix http://travis-ci.org/#!/svenfuchs/remote_notifications/builds/1829214 but still has a missing `Gemfile.2.3.x` where I wasn't sure if you forgot to add it or just copied the matrix definition to try it out quickly.
